### PR TITLE
fix: decode URL-encoded characters when normalizing GitHub URLs

### DIFF
--- a/github_dlr/source.py
+++ b/github_dlr/source.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import aiohttp
 import emoji
@@ -20,7 +20,7 @@ def normalize_github_url(github_url: str):
         raise ValueError("Not a valid Github URL")
 
     parsed_url = urlparse(github_url)
-    github_path = parsed_url.path.split("/")
+    github_path = [unquote(part) for part in parsed_url.path.split("/")]
     owner = github_path[1]
     repo = github_path[2]
     branch = github_path[4]

--- a/tests/normalize_test.py
+++ b/tests/normalize_test.py
@@ -64,3 +64,77 @@ def test_normalize_github_url_invalid_url():
         normalize_github_url(
             "https://gitlab.com/AnimeChan/animechan/tree/main/client/public/images/logo.png"
         )
+
+
+def test_normalize_github_url_percent_encoded_space_in_target():
+    # Browser address bar produces %20-encoded URLs. The decoded form is what
+    # we want on disk and what aiohttp will (re-)encode for the API call.
+    expected_result = {
+        "owner": "ipython",
+        "repo": "ipython",
+        "branch": "main",
+        "target": "IPython Kernel",
+        "target_path": "examples",
+    }
+    result = normalize_github_url(
+        "https://github.com/ipython/ipython/tree/main/examples/IPython%20Kernel"
+    )
+    assert result == expected_result
+
+
+def test_normalize_github_url_literal_space_in_target():
+    expected_result = {
+        "owner": "ipython",
+        "repo": "ipython",
+        "branch": "main",
+        "target": "IPython Kernel",
+        "target_path": "examples",
+    }
+    result = normalize_github_url(
+        "https://github.com/ipython/ipython/tree/main/examples/IPython Kernel"
+    )
+    assert result == expected_result
+
+
+def test_normalize_github_url_encoded_chars_in_intermediate_path():
+    expected_result = {
+        "owner": "owner",
+        "repo": "repo",
+        "branch": "main",
+        "target": "file.txt",
+        "target_path": "my docs/sub dir",
+    }
+    result = normalize_github_url(
+        "https://github.com/owner/repo/tree/main/my%20docs/sub%20dir/file.txt"
+    )
+    assert result == expected_result
+
+
+def test_normalize_github_url_non_ascii_target():
+    # Cyrillic "документы" — encoded form is what GitHub serves in the address bar.
+    expected_result = {
+        "owner": "owner",
+        "repo": "repo",
+        "branch": "main",
+        "target": "документы",
+        "target_path": "src",
+    }
+    result = normalize_github_url(
+        "https://github.com/owner/repo/tree/main/src/%D0%B4%D0%BE%D0%BA%D1%83%D0%BC%D0%B5%D0%BD%D1%82%D1%8B"
+    )
+    assert result == expected_result
+
+
+def test_normalize_github_url_special_chars_in_target():
+    # Parentheses and `+` — common in C++/sample folder names.
+    expected_result = {
+        "owner": "owner",
+        "repo": "repo",
+        "branch": "main",
+        "target": "C++ (samples)",
+        "target_path": "src",
+    }
+    result = normalize_github_url(
+        "https://github.com/owner/repo/tree/main/src/C%2B%2B%20%28samples%29"
+    )
+    assert result == expected_result


### PR DESCRIPTION
Fixes #7 — folder names containing percent-encoded characters (e.g., `%20` for spaces) were saved on disk with the literal escape sequence instead of the decoded name, fixed by applying `urllib.parse.unquote` to each path segment in `normalize_github_url`.