### PR TITLE
docs: simplify README and bump copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2025 Rocktim Saikia (https://github.com/sponsors/rocktimsaikia)
+Copyright © 2026 Rocktim Saikia (https://github.com/sponsors/rocktimsaikia)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Requires Python 3.8+.
 pip install github-dlr
 ```
 
+Or with [pipx](https://pipx.pypa.io/):
+
+```sh
+pipx install github-dlr
+```
+
 ## Usage
 
 Pass any GitHub file or folder URL:

--- a/README.md
+++ b/README.md
@@ -1,67 +1,35 @@
 # Github-dlr
 
-Download individual files and folders from GitHub recursively.
+Download files and folders from GitHub without cloning the whole repo.
 
 [![Tests](https://github.com/rocktimsaikia/github-dlr/actions/workflows/tests.yml/badge.svg)](https://github.com/rocktimsaikia/github-dlr/actions/workflows/tests.yml)
 
 [![Demo](https://github.com/user-attachments/assets/49e4068c-1090-4c9e-9b56-59388ff407a9)](https://github.com/user-attachments/assets/8927d4ef-f8e1-4699-b75b-b7e28291d509)
 
-## Motivation
-
-The project aims to save time and resources by allowing users to download only the specific folders and files they need from a GitHub repository, without the hassle of cloning the entire repo. It's designed for efficiency, making development and learning more streamlined.
-
 ## Install
 
-Requires Python version 3.8 or higher.
+Requires Python 3.8+.
 
 ```sh
 pip install github-dlr
 ```
 
-or using [pipx](https://pipx.pypa.io/)
-
-```sh
-pipx install github-dlr
-```
-
 ## Usage
 
-> [!NOTE]
-> Using the tool is straightforward, copy the GitHub URL of the target repository folder and paste it after the command `github-dlr` or it's alias `gh-dlr`.
+Pass any GitHub file or folder URL:
 
 ```sh
-github-dlr <github_path>
-
-# Basic Example
 github-dlr https://github.com/makccr/wallpapers/blob/master/wallpapers/space
 ```
 
-> [!NOTE]
-> By default it will download the entire folder from GitHub and place in the current directory from where the command is being executed. If you want to specify a different output directory, you can do it via the `--output` or `-o` flag.
+Use `-o` to choose an output directory (defaults to the current one):
 
 ```sh
-github-dlr --output wallpapers https://github.com/makccr/wallpapers/blob/master/wallpapers/space
+github-dlr -o wallpapers https://github.com/makccr/wallpapers/blob/master/wallpapers/space
 ```
 
-\
-Find all available options using `--help`
+`gh-dlr` works as a shorter alias.
 
-```sh
-usage: github-dlr [-h] [-o] [-v] github_path
+## License
 
-Download folders and files from Github.
-
-positional arguments:
-  github_path     Github directory full URL path
-
-options:
-  -h, --help      show this help message and exit
-  -o, --output   Destination directory to download to
-  -v, --version   show program version number and exit
-
-Thanks for using github-dlr!
-```
-
-## LICENSE
-
-[MIT](./LICENSE) License &copy; [Rocktim Saikia](https://rocktimsaikia.dev) 2025
+[MIT](./LICENSE) &copy; [Rocktim Saikia](https://rocktimsaikia.dev) 2026


### PR DESCRIPTION
Trimmed the README down to install/usage essentials and updated the copyright year to `2026` in `README.md` and `LICENSE`.